### PR TITLE
fix: refence to default branch not custom branch

### DIFF
--- a/Util/Docker/carla-ue4.dockerfile
+++ b/Util/Docker/carla-ue4.dockerfile
@@ -147,9 +147,8 @@ WORKDIR /workspaces
 # ------------------------------------------------------------------------------
 # Install CARLA 0.9.15.2
 # ------------------------------------------------------------------------------
-ARG CARLA_GIT_TAG="0.9.15.2"
-ARG BRANCH="feature/carla-${CARLA_GIT_TAG}-jammy-devcontainer"
-ARG CLONE_DIR="carla-${CARLA_GIT_TAG}"
+ARG BRANCH=ue4-dev
+ARG CLONE_DIR=carla-ue4-dev
 
 RUN git clone --depth 1 --branch ${BRANCH} https://github.com/wambitz/carla.git ${CLONE_DIR}
 

--- a/Util/Docker/carla.dockerfile
+++ b/Util/Docker/carla.dockerfile
@@ -79,7 +79,8 @@ RUN apt-get install -y \
     libtiff5-dev \
     libjpeg-dev \
     autoconf \
-    rsync
+    rsync \
+    unzip
 
 # ------------------------------------------------------------------------------
 # (Optional) Install CARLA build packaging depenencies(make build.utils)


### PR DESCRIPTION
# Hotfix: Update Default Branch Reference & Sync with Official Repository  

## Summary  
This hotfix updates the repository to reference the correct default branch and synchronizes the latest changes from the official CARLA repository. The update ensures that missing files, including the `rss` directory, are included, resolving packaging issues.

## Changes  
- Updated the default branch reference to ensure proper tracking.  
- Synced the latest upstream changes from the official CARLA repository.  
- Included the missing `rss` directory from upstream, fixing errors when running `make package`.  

## Motivation  
The `make package` command was failing due to missing files in `PythonAPI/examples/rss`, which were added in recent commits to the upstream repository. This PR ensures the repository is fully up-to-date and avoids future inconsistencies.  

## How to Test  
1. Checkout the branch:  
   ```bash
   git checkout hotfix/update-default-branch
   ```
2. Build and package CARLA:  
   ```bash
   make clean
   make PythonAPI
   make package
   ```
3. Verify that the `rss` directory exists:  
   ```bash
   ls PythonAPI/examples/rss
   ```

## Expected Behavior  
- The `rss` directory should now be present in `PythonAPI/examples/`.  
- `make package` should complete successfully without `rsync` errors.  

## Fixed error

```bash
rsync: [sender] change_dir "/workspaces/carla-0.9.15.2/./PythonAPI/examples/rss" failed: No such file or directory (2)
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1338) [sender=3.2.7]
make: *** [Util/BuildTools/Linux.mk:17: package] Error 23
```